### PR TITLE
fixed leap years in time coord

### DIFF
--- a/xgrads/core.py
+++ b/xgrads/core.py
@@ -698,8 +698,21 @@ class CtlDescriptor(object):
         else:
             start = GrADStime_to_datetime64(strTime)
             intv  = GrADS_increment_to_timedelta64(incre)
-            
-            return np.arange(start, start + intv * tnum, intv)
+
+            if self.cal365Days:
+
+                lst = []
+                while len(lst) < tnum:
+                    isfeb29 = (start.item().day == 29) and (start.item().month == 2)
+                    if not isfeb29:
+                        lst.append(start)
+                    start += intv
+
+                return np.asarray(lst)
+
+            else:
+
+                return np.arange(start, start + intv * tnum, intv)
 
     def __repr__(self):
         """Print this class as a string"""


### PR DESCRIPTION
Fixes implementation of `_times_to_array` which currently ignores `cal365Days` and therefore includes leap days even when `cal365Days = True`.