### PR TITLE
fix: change xgrads/core.py

### DIFF
--- a/xgrads/core.py
+++ b/xgrads/core.py
@@ -232,9 +232,7 @@ class CtlDescriptor(object):
         
         if kwargs.get('file'):
             abspath = kwargs['file']
-            
-            if not '/' in abspath: # thanks to Baofeng Jiao from IAP
-                abspath = './' + abspath
+            abspath = os.path.abspath(abspath)
             
             if os.path.getsize(abspath) / (1024.0*1024.0) > 2:
                 raise Exception('ctl file is too large (> 2 MB)')


### PR DESCRIPTION
Provide better compatibility with Windows file systems.

The method in [core.py](https://github.com/miniufo/xgrads/blob/master/xgrads/core.py#L236) that deals with the path (add `./` before the filename) can raise an Error under the Windows file systems (path split by `\`):
<img width="1605" height="589" alt="image" src="https://github.com/user-attachments/assets/1a0bf59e-8565-48cd-aed2-b3f9afcecaee" />
How about letting os.path to do the things?